### PR TITLE
Fix self closing tags bug in templates fixes (#67)

### DIFF
--- a/docs/3024-Day/3024-Day.md
+++ b/docs/3024-Day/3024-Day.md
@@ -9,7 +9,7 @@ permalink: /3024-Day/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/3024-Night/3024-Night.md
+++ b/docs/3024-Night/3024-Night.md
@@ -9,7 +9,7 @@ permalink: /3024-Night/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Aardvark-Blue/Aardvark-Blue.md
+++ b/docs/Aardvark-Blue/Aardvark-Blue.md
@@ -9,7 +9,7 @@ permalink: /Aardvark-Blue/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Abernathy/Abernathy.md
+++ b/docs/Abernathy/Abernathy.md
@@ -9,7 +9,7 @@ permalink: /Abernathy/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Adventure/Adventure.md
+++ b/docs/Adventure/Adventure.md
@@ -9,7 +9,7 @@ permalink: /Adventure/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/AdventureTime/AdventureTime.md
+++ b/docs/AdventureTime/AdventureTime.md
@@ -9,7 +9,7 @@ permalink: /AdventureTime/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Afterglow/Afterglow.md
+++ b/docs/Afterglow/Afterglow.md
@@ -9,7 +9,7 @@ permalink: /Afterglow/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Alabaster/Alabaster.md
+++ b/docs/Alabaster/Alabaster.md
@@ -9,7 +9,7 @@ permalink: /Alabaster/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/AlienBlood/AlienBlood.md
+++ b/docs/AlienBlood/AlienBlood.md
@@ -9,7 +9,7 @@ permalink: /AlienBlood/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Andromeda/Andromeda.md
+++ b/docs/Andromeda/Andromeda.md
@@ -9,7 +9,7 @@ permalink: /Andromeda/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Apple-Classic/Apple-Classic.md
+++ b/docs/Apple-Classic/Apple-Classic.md
@@ -9,7 +9,7 @@ permalink: /Apple-Classic/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Apple-System-Colors/Apple-System-Colors.md
+++ b/docs/Apple-System-Colors/Apple-System-Colors.md
@@ -9,7 +9,7 @@ permalink: /Apple-System-Colors/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Argonaut/Argonaut.md
+++ b/docs/Argonaut/Argonaut.md
@@ -9,7 +9,7 @@ permalink: /Argonaut/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Arthur/Arthur.md
+++ b/docs/Arthur/Arthur.md
@@ -9,7 +9,7 @@ permalink: /Arthur/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/AtelierSulphurpool/AtelierSulphurpool.md
+++ b/docs/AtelierSulphurpool/AtelierSulphurpool.md
@@ -9,7 +9,7 @@ permalink: /AtelierSulphurpool/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Atom/Atom.md
+++ b/docs/Atom/Atom.md
@@ -9,7 +9,7 @@ permalink: /Atom/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/AtomOneLight/AtomOneLight.md
+++ b/docs/AtomOneLight/AtomOneLight.md
@@ -9,7 +9,7 @@ permalink: /AtomOneLight/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Aurora/Aurora.md
+++ b/docs/Aurora/Aurora.md
@@ -9,7 +9,7 @@ permalink: /Aurora/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Ayu-Mirage/Ayu-Mirage.md
+++ b/docs/Ayu-Mirage/Ayu-Mirage.md
@@ -9,7 +9,7 @@ permalink: /Ayu-Mirage/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Banana-Blueberry/Banana-Blueberry.md
+++ b/docs/Banana-Blueberry/Banana-Blueberry.md
@@ -9,7 +9,7 @@ permalink: /Banana-Blueberry/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Batman/Batman.md
+++ b/docs/Batman/Batman.md
@@ -9,7 +9,7 @@ permalink: /Batman/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Belafonte-Day/Belafonte-Day.md
+++ b/docs/Belafonte-Day/Belafonte-Day.md
@@ -9,7 +9,7 @@ permalink: /Belafonte-Day/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Belafonte-Night/Belafonte-Night.md
+++ b/docs/Belafonte-Night/Belafonte-Night.md
@@ -9,7 +9,7 @@ permalink: /Belafonte-Night/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/BirdsOfParadise/BirdsOfParadise.md
+++ b/docs/BirdsOfParadise/BirdsOfParadise.md
@@ -9,7 +9,7 @@ permalink: /BirdsOfParadise/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Blazer/Blazer.md
+++ b/docs/Blazer/Blazer.md
@@ -9,7 +9,7 @@ permalink: /Blazer/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Blue-Matrix/Blue-Matrix.md
+++ b/docs/Blue-Matrix/Blue-Matrix.md
@@ -9,7 +9,7 @@ permalink: /Blue-Matrix/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/BlueBerryPie/BlueBerryPie.md
+++ b/docs/BlueBerryPie/BlueBerryPie.md
@@ -9,7 +9,7 @@ permalink: /BlueBerryPie/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/BlueDolphin/BlueDolphin.md
+++ b/docs/BlueDolphin/BlueDolphin.md
@@ -9,7 +9,7 @@ permalink: /BlueDolphin/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/BlulocoDark/BlulocoDark.md
+++ b/docs/BlulocoDark/BlulocoDark.md
@@ -9,7 +9,7 @@ permalink: /BlulocoDark/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/BlulocoLight/BlulocoLight.md
+++ b/docs/BlulocoLight/BlulocoLight.md
@@ -9,7 +9,7 @@ permalink: /BlulocoLight/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Borland/Borland.md
+++ b/docs/Borland/Borland.md
@@ -9,7 +9,7 @@ permalink: /Borland/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Breeze/Breeze.md
+++ b/docs/Breeze/Breeze.md
@@ -9,7 +9,7 @@ permalink: /Breeze/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Bright-Lights/Bright-Lights.md
+++ b/docs/Bright-Lights/Bright-Lights.md
@@ -9,7 +9,7 @@ permalink: /Bright-Lights/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Broadcast/Broadcast.md
+++ b/docs/Broadcast/Broadcast.md
@@ -9,7 +9,7 @@ permalink: /Broadcast/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Brogrammer/Brogrammer.md
+++ b/docs/Brogrammer/Brogrammer.md
@@ -9,7 +9,7 @@ permalink: /Brogrammer/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Builtin-Dark/Builtin-Dark.md
+++ b/docs/Builtin-Dark/Builtin-Dark.md
@@ -9,7 +9,7 @@ permalink: /Builtin-Dark/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Builtin-Light/Builtin-Light.md
+++ b/docs/Builtin-Light/Builtin-Light.md
@@ -9,7 +9,7 @@ permalink: /Builtin-Light/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Builtin-Pastel-Dark/Builtin-Pastel-Dark.md
+++ b/docs/Builtin-Pastel-Dark/Builtin-Pastel-Dark.md
@@ -9,7 +9,7 @@ permalink: /Builtin-Pastel-Dark/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Builtin-Solarized-Dark/Builtin-Solarized-Dark.md
+++ b/docs/Builtin-Solarized-Dark/Builtin-Solarized-Dark.md
@@ -9,7 +9,7 @@ permalink: /Builtin-Solarized-Dark/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Builtin-Solarized-Light/Builtin-Solarized-Light.md
+++ b/docs/Builtin-Solarized-Light/Builtin-Solarized-Light.md
@@ -9,7 +9,7 @@ permalink: /Builtin-Solarized-Light/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Builtin-Tango-Dark/Builtin-Tango-Dark.md
+++ b/docs/Builtin-Tango-Dark/Builtin-Tango-Dark.md
@@ -9,7 +9,7 @@ permalink: /Builtin-Tango-Dark/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Builtin-Tango-Light/Builtin-Tango-Light.md
+++ b/docs/Builtin-Tango-Light/Builtin-Tango-Light.md
@@ -9,7 +9,7 @@ permalink: /Builtin-Tango-Light/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/C64/C64.md
+++ b/docs/C64/C64.md
@@ -9,7 +9,7 @@ permalink: /C64/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/CGA/CGA.md
+++ b/docs/CGA/CGA.md
@@ -9,7 +9,7 @@ permalink: /CGA/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/CLRS/CLRS.md
+++ b/docs/CLRS/CLRS.md
@@ -9,7 +9,7 @@ permalink: /CLRS/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Calamity/Calamity.md
+++ b/docs/Calamity/Calamity.md
@@ -9,7 +9,7 @@ permalink: /Calamity/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Chalk/Chalk.md
+++ b/docs/Chalk/Chalk.md
@@ -9,7 +9,7 @@ permalink: /Chalk/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Chalkboard/Chalkboard.md
+++ b/docs/Chalkboard/Chalkboard.md
@@ -9,7 +9,7 @@ permalink: /Chalkboard/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/ChallengerDeep/ChallengerDeep.md
+++ b/docs/ChallengerDeep/ChallengerDeep.md
@@ -9,7 +9,7 @@ permalink: /ChallengerDeep/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Chester/Chester.md
+++ b/docs/Chester/Chester.md
@@ -9,7 +9,7 @@ permalink: /Chester/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Ciapre/Ciapre.md
+++ b/docs/Ciapre/Ciapre.md
@@ -9,7 +9,7 @@ permalink: /Ciapre/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Cobalt-Neon/Cobalt-Neon.md
+++ b/docs/Cobalt-Neon/Cobalt-Neon.md
@@ -9,7 +9,7 @@ permalink: /Cobalt-Neon/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Cobalt2/Cobalt2.md
+++ b/docs/Cobalt2/Cobalt2.md
@@ -9,7 +9,7 @@ permalink: /Cobalt2/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/CrayonPonyFish/CrayonPonyFish.md
+++ b/docs/CrayonPonyFish/CrayonPonyFish.md
@@ -9,7 +9,7 @@ permalink: /CrayonPonyFish/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/CutiePro/CutiePro.md
+++ b/docs/CutiePro/CutiePro.md
@@ -9,7 +9,7 @@ permalink: /CutiePro/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Cyberdyne/Cyberdyne.md
+++ b/docs/Cyberdyne/Cyberdyne.md
@@ -9,7 +9,7 @@ permalink: /Cyberdyne/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Dark+/Dark+.md
+++ b/docs/Dark+/Dark+.md
@@ -9,7 +9,7 @@ permalink: /Dark+/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Dark-Pastel/Dark-Pastel.md
+++ b/docs/Dark-Pastel/Dark-Pastel.md
@@ -9,7 +9,7 @@ permalink: /Dark-Pastel/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Darkside/Darkside.md
+++ b/docs/Darkside/Darkside.md
@@ -9,7 +9,7 @@ permalink: /Darkside/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Desert/Desert.md
+++ b/docs/Desert/Desert.md
@@ -9,7 +9,7 @@ permalink: /Desert/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/DimmedMonokai/DimmedMonokai.md
+++ b/docs/DimmedMonokai/DimmedMonokai.md
@@ -9,7 +9,7 @@ permalink: /DimmedMonokai/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Django/Django.md
+++ b/docs/Django/Django.md
@@ -9,7 +9,7 @@ permalink: /Django/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/DjangoRebornAgain/DjangoRebornAgain.md
+++ b/docs/DjangoRebornAgain/DjangoRebornAgain.md
@@ -9,7 +9,7 @@ permalink: /DjangoRebornAgain/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/DjangoSmooth/DjangoSmooth.md
+++ b/docs/DjangoSmooth/DjangoSmooth.md
@@ -9,7 +9,7 @@ permalink: /DjangoSmooth/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Doom-Peacock/Doom-Peacock.md
+++ b/docs/Doom-Peacock/Doom-Peacock.md
@@ -9,7 +9,7 @@ permalink: /Doom-Peacock/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/DoomOne/DoomOne.md
+++ b/docs/DoomOne/DoomOne.md
@@ -9,7 +9,7 @@ permalink: /DoomOne/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/DotGov/DotGov.md
+++ b/docs/DotGov/DotGov.md
@@ -9,7 +9,7 @@ permalink: /DotGov/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Dracula+/Dracula+.md
+++ b/docs/Dracula+/Dracula+.md
@@ -9,7 +9,7 @@ permalink: /Dracula+/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Dracula/Dracula.md
+++ b/docs/Dracula/Dracula.md
@@ -9,7 +9,7 @@ permalink: /Dracula/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Duotone-Dark/Duotone-Dark.md
+++ b/docs/Duotone-Dark/Duotone-Dark.md
@@ -9,7 +9,7 @@ permalink: /Duotone-Dark/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/ENCOM/ENCOM.md
+++ b/docs/ENCOM/ENCOM.md
@@ -9,7 +9,7 @@ permalink: /ENCOM/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Earthsong/Earthsong.md
+++ b/docs/Earthsong/Earthsong.md
@@ -9,7 +9,7 @@ permalink: /Earthsong/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Elemental/Elemental.md
+++ b/docs/Elemental/Elemental.md
@@ -9,7 +9,7 @@ permalink: /Elemental/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Elementary/Elementary.md
+++ b/docs/Elementary/Elementary.md
@@ -9,7 +9,7 @@ permalink: /Elementary/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Espresso-Libre/Espresso-Libre.md
+++ b/docs/Espresso-Libre/Espresso-Libre.md
@@ -9,7 +9,7 @@ permalink: /Espresso-Libre/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Espresso/Espresso.md
+++ b/docs/Espresso/Espresso.md
@@ -9,7 +9,7 @@ permalink: /Espresso/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Everblush/Everblush.md
+++ b/docs/Everblush/Everblush.md
@@ -9,7 +9,7 @@ permalink: /Everblush/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Fahrenheit/Fahrenheit.md
+++ b/docs/Fahrenheit/Fahrenheit.md
@@ -9,7 +9,7 @@ permalink: /Fahrenheit/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Fairyfloss/Fairyfloss.md
+++ b/docs/Fairyfloss/Fairyfloss.md
@@ -9,7 +9,7 @@ permalink: /Fairyfloss/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Fideloper/Fideloper.md
+++ b/docs/Fideloper/Fideloper.md
@@ -9,7 +9,7 @@ permalink: /Fideloper/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Firefly-Traditional/Firefly-Traditional.md
+++ b/docs/Firefly-Traditional/Firefly-Traditional.md
@@ -9,7 +9,7 @@ permalink: /Firefly-Traditional/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/FirefoxDev/FirefoxDev.md
+++ b/docs/FirefoxDev/FirefoxDev.md
@@ -9,7 +9,7 @@ permalink: /FirefoxDev/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Firewatch/Firewatch.md
+++ b/docs/Firewatch/Firewatch.md
@@ -9,7 +9,7 @@ permalink: /Firewatch/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/FishTank/FishTank.md
+++ b/docs/FishTank/FishTank.md
@@ -9,7 +9,7 @@ permalink: /FishTank/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Flat/Flat.md
+++ b/docs/Flat/Flat.md
@@ -9,7 +9,7 @@ permalink: /Flat/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Flatland/Flatland.md
+++ b/docs/Flatland/Flatland.md
@@ -9,7 +9,7 @@ permalink: /Flatland/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Floraverse/Floraverse.md
+++ b/docs/Floraverse/Floraverse.md
@@ -9,7 +9,7 @@ permalink: /Floraverse/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/ForestBlue/ForestBlue.md
+++ b/docs/ForestBlue/ForestBlue.md
@@ -9,7 +9,7 @@ permalink: /ForestBlue/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Framer/Framer.md
+++ b/docs/Framer/Framer.md
@@ -9,7 +9,7 @@ permalink: /Framer/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/FrontEndDelight/FrontEndDelight.md
+++ b/docs/FrontEndDelight/FrontEndDelight.md
@@ -9,7 +9,7 @@ permalink: /FrontEndDelight/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/FunForrest/FunForrest.md
+++ b/docs/FunForrest/FunForrest.md
@@ -9,7 +9,7 @@ permalink: /FunForrest/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Galaxy/Galaxy.md
+++ b/docs/Galaxy/Galaxy.md
@@ -9,7 +9,7 @@ permalink: /Galaxy/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Galizur/Galizur.md
+++ b/docs/Galizur/Galizur.md
@@ -9,7 +9,7 @@ permalink: /Galizur/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/GitHub-Dark/GitHub-Dark.md
+++ b/docs/GitHub-Dark/GitHub-Dark.md
@@ -9,7 +9,7 @@ permalink: /GitHub-Dark/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Github/Github.md
+++ b/docs/Github/Github.md
@@ -9,7 +9,7 @@ permalink: /Github/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Glacier/Glacier.md
+++ b/docs/Glacier/Glacier.md
@@ -9,7 +9,7 @@ permalink: /Glacier/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Grape/Grape.md
+++ b/docs/Grape/Grape.md
@@ -9,7 +9,7 @@ permalink: /Grape/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Grass/Grass.md
+++ b/docs/Grass/Grass.md
@@ -9,7 +9,7 @@ permalink: /Grass/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Grey-green/Grey-green.md
+++ b/docs/Grey-green/Grey-green.md
@@ -9,7 +9,7 @@ permalink: /Grey-green/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Gruvbox-Light/Gruvbox-Light.md
+++ b/docs/Gruvbox-Light/Gruvbox-Light.md
@@ -9,7 +9,7 @@ permalink: /Gruvbox-Light/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/GruvboxDark/GruvboxDark.md
+++ b/docs/GruvboxDark/GruvboxDark.md
@@ -9,7 +9,7 @@ permalink: /GruvboxDark/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/GruvboxDarkHard/GruvboxDarkHard.md
+++ b/docs/GruvboxDarkHard/GruvboxDarkHard.md
@@ -9,7 +9,7 @@ permalink: /GruvboxDarkHard/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/GruvboxLight/GruvboxLight.md
+++ b/docs/GruvboxLight/GruvboxLight.md
@@ -9,7 +9,7 @@ permalink: /GruvboxLight/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Guezwhoz/Guezwhoz.md
+++ b/docs/Guezwhoz/Guezwhoz.md
@@ -9,7 +9,7 @@ permalink: /Guezwhoz/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/HaX0R-BLUE/HaX0R-BLUE.md
+++ b/docs/HaX0R-BLUE/HaX0R-BLUE.md
@@ -9,7 +9,7 @@ permalink: /HaX0R-BLUE/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/HaX0R-GR33N/HaX0R-GR33N.md
+++ b/docs/HaX0R-GR33N/HaX0R-GR33N.md
@@ -9,7 +9,7 @@ permalink: /HaX0R-GR33N/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/HaX0R-R3D/HaX0R-R3D.md
+++ b/docs/HaX0R-R3D/HaX0R-R3D.md
@@ -9,7 +9,7 @@ permalink: /HaX0R-R3D/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Hacktober/Hacktober.md
+++ b/docs/Hacktober/Hacktober.md
@@ -9,7 +9,7 @@ permalink: /Hacktober/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Hardcore/Hardcore.md
+++ b/docs/Hardcore/Hardcore.md
@@ -9,7 +9,7 @@ permalink: /Hardcore/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Harper/Harper.md
+++ b/docs/Harper/Harper.md
@@ -9,7 +9,7 @@ permalink: /Harper/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Highway/Highway.md
+++ b/docs/Highway/Highway.md
@@ -9,7 +9,7 @@ permalink: /Highway/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Hipster-Green/Hipster-Green.md
+++ b/docs/Hipster-Green/Hipster-Green.md
@@ -9,7 +9,7 @@ permalink: /Hipster-Green/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Hivacruz/Hivacruz.md
+++ b/docs/Hivacruz/Hivacruz.md
@@ -9,7 +9,7 @@ permalink: /Hivacruz/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Homebrew/Homebrew.md
+++ b/docs/Homebrew/Homebrew.md
@@ -9,7 +9,7 @@ permalink: /Homebrew/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Hopscotch-256/Hopscotch-256.md
+++ b/docs/Hopscotch-256/Hopscotch-256.md
@@ -9,7 +9,7 @@ permalink: /Hopscotch-256/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Hopscotch/Hopscotch.md
+++ b/docs/Hopscotch/Hopscotch.md
@@ -9,7 +9,7 @@ permalink: /Hopscotch/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Hurtado/Hurtado.md
+++ b/docs/Hurtado/Hurtado.md
@@ -9,7 +9,7 @@ permalink: /Hurtado/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Hybrid/Hybrid.md
+++ b/docs/Hybrid/Hybrid.md
@@ -9,7 +9,7 @@ permalink: /Hybrid/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/IC-Green-PPL/IC-Green-PPL.md
+++ b/docs/IC-Green-PPL/IC-Green-PPL.md
@@ -9,7 +9,7 @@ permalink: /IC-Green-PPL/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/IC-Orange-PPL/IC-Orange-PPL.md
+++ b/docs/IC-Orange-PPL/IC-Orange-PPL.md
@@ -9,7 +9,7 @@ permalink: /IC-Orange-PPL/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/IR-Black/IR-Black.md
+++ b/docs/IR-Black/IR-Black.md
@@ -9,7 +9,7 @@ permalink: /IR-Black/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Jackie-Brown/Jackie-Brown.md
+++ b/docs/Jackie-Brown/Jackie-Brown.md
@@ -9,7 +9,7 @@ permalink: /Jackie-Brown/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Japanesque/Japanesque.md
+++ b/docs/Japanesque/Japanesque.md
@@ -9,7 +9,7 @@ permalink: /Japanesque/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Jellybeans/Jellybeans.md
+++ b/docs/Jellybeans/Jellybeans.md
@@ -9,7 +9,7 @@ permalink: /Jellybeans/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/JetBrains-Darcula/JetBrains-Darcula.md
+++ b/docs/JetBrains-Darcula/JetBrains-Darcula.md
@@ -9,7 +9,7 @@ permalink: /JetBrains-Darcula/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Kibble/Kibble.md
+++ b/docs/Kibble/Kibble.md
@@ -9,7 +9,7 @@ permalink: /Kibble/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Kolorit/Kolorit.md
+++ b/docs/Kolorit/Kolorit.md
@@ -9,7 +9,7 @@ permalink: /Kolorit/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Konsolas/Konsolas.md
+++ b/docs/Konsolas/Konsolas.md
@@ -9,7 +9,7 @@ permalink: /Konsolas/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Lab-Fox/Lab-Fox.md
+++ b/docs/Lab-Fox/Lab-Fox.md
@@ -9,7 +9,7 @@ permalink: /Lab-Fox/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Laser/Laser.md
+++ b/docs/Laser/Laser.md
@@ -9,7 +9,7 @@ permalink: /Laser/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Later-This-Evening/Later-This-Evening.md
+++ b/docs/Later-This-Evening/Later-This-Evening.md
@@ -9,7 +9,7 @@ permalink: /Later-This-Evening/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Lavandula/Lavandula.md
+++ b/docs/Lavandula/Lavandula.md
@@ -9,7 +9,7 @@ permalink: /Lavandula/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/LiquidCarbon/LiquidCarbon.md
+++ b/docs/LiquidCarbon/LiquidCarbon.md
@@ -9,7 +9,7 @@ permalink: /LiquidCarbon/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/LiquidCarbonTransparent/LiquidCarbonTransparent.md
+++ b/docs/LiquidCarbonTransparent/LiquidCarbonTransparent.md
@@ -9,7 +9,7 @@ permalink: /LiquidCarbonTransparent/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/LiquidCarbonTransparentInverse/LiquidCarbonTransparentInverse.md
+++ b/docs/LiquidCarbonTransparentInverse/LiquidCarbonTransparentInverse.md
@@ -9,7 +9,7 @@ permalink: /LiquidCarbonTransparentInverse/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Man-Page/Man-Page.md
+++ b/docs/Man-Page/Man-Page.md
@@ -9,7 +9,7 @@ permalink: /Man-Page/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Mariana/Mariana.md
+++ b/docs/Mariana/Mariana.md
@@ -9,7 +9,7 @@ permalink: /Mariana/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Material/Material.md
+++ b/docs/Material/Material.md
@@ -9,7 +9,7 @@ permalink: /Material/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/MaterialDark/MaterialDark.md
+++ b/docs/MaterialDark/MaterialDark.md
@@ -9,7 +9,7 @@ permalink: /MaterialDark/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/MaterialDarker/MaterialDarker.md
+++ b/docs/MaterialDarker/MaterialDarker.md
@@ -9,7 +9,7 @@ permalink: /MaterialDarker/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/MaterialDesignColors/MaterialDesignColors.md
+++ b/docs/MaterialDesignColors/MaterialDesignColors.md
@@ -9,7 +9,7 @@ permalink: /MaterialDesignColors/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/MaterialOcean/MaterialOcean.md
+++ b/docs/MaterialOcean/MaterialOcean.md
@@ -9,7 +9,7 @@ permalink: /MaterialOcean/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Mathias/Mathias.md
+++ b/docs/Mathias/Mathias.md
@@ -9,7 +9,7 @@ permalink: /Mathias/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Medallion/Medallion.md
+++ b/docs/Medallion/Medallion.md
@@ -9,7 +9,7 @@ permalink: /Medallion/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Mellifluous/Mellifluous.md
+++ b/docs/Mellifluous/Mellifluous.md
@@ -9,7 +9,7 @@ permalink: /Mellifluous/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Mirage/Mirage.md
+++ b/docs/Mirage/Mirage.md
@@ -9,7 +9,7 @@ permalink: /Mirage/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Misterioso/Misterioso.md
+++ b/docs/Misterioso/Misterioso.md
@@ -9,7 +9,7 @@ permalink: /Misterioso/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Molokai/Molokai.md
+++ b/docs/Molokai/Molokai.md
@@ -9,7 +9,7 @@ permalink: /Molokai/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/MonaLisa/MonaLisa.md
+++ b/docs/MonaLisa/MonaLisa.md
@@ -9,7 +9,7 @@ permalink: /MonaLisa/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Monokai-Remastered/Monokai-Remastered.md
+++ b/docs/Monokai-Remastered/Monokai-Remastered.md
@@ -9,7 +9,7 @@ permalink: /Monokai-Remastered/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Monokai-Soda/Monokai-Soda.md
+++ b/docs/Monokai-Soda/Monokai-Soda.md
@@ -9,7 +9,7 @@ permalink: /Monokai-Soda/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Monokai-Vivid/Monokai-Vivid.md
+++ b/docs/Monokai-Vivid/Monokai-Vivid.md
@@ -9,7 +9,7 @@ permalink: /Monokai-Vivid/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/N0tch2k/N0tch2k.md
+++ b/docs/N0tch2k/N0tch2k.md
@@ -9,7 +9,7 @@ permalink: /N0tch2k/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Neon/Neon.md
+++ b/docs/Neon/Neon.md
@@ -9,7 +9,7 @@ permalink: /Neon/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Neopolitan/Neopolitan.md
+++ b/docs/Neopolitan/Neopolitan.md
@@ -9,7 +9,7 @@ permalink: /Neopolitan/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Neutron/Neutron.md
+++ b/docs/Neutron/Neutron.md
@@ -9,7 +9,7 @@ permalink: /Neutron/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Night-Owlish-Light/Night-Owlish-Light.md
+++ b/docs/Night-Owlish-Light/Night-Owlish-Light.md
@@ -9,7 +9,7 @@ permalink: /Night-Owlish-Light/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/NightLion-v1/NightLion-v1.md
+++ b/docs/NightLion-v1/NightLion-v1.md
@@ -9,7 +9,7 @@ permalink: /NightLion-v1/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/NightLion-v2/NightLion-v2.md
+++ b/docs/NightLion-v2/NightLion-v2.md
@@ -9,7 +9,7 @@ permalink: /NightLion-v2/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Nocturnal-Winter/Nocturnal-Winter.md
+++ b/docs/Nocturnal-Winter/Nocturnal-Winter.md
@@ -9,7 +9,7 @@ permalink: /Nocturnal-Winter/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Novel/Novel.md
+++ b/docs/Novel/Novel.md
@@ -9,7 +9,7 @@ permalink: /Novel/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/NvimDark/NvimDark.md
+++ b/docs/NvimDark/NvimDark.md
@@ -9,7 +9,7 @@ permalink: /NvimDark/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/NvimLight/NvimLight.md
+++ b/docs/NvimLight/NvimLight.md
@@ -9,7 +9,7 @@ permalink: /NvimLight/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Obsidian/Obsidian.md
+++ b/docs/Obsidian/Obsidian.md
@@ -9,7 +9,7 @@ permalink: /Obsidian/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Ocean/Ocean.md
+++ b/docs/Ocean/Ocean.md
@@ -9,7 +9,7 @@ permalink: /Ocean/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Oceanic-Next/Oceanic-Next.md
+++ b/docs/Oceanic-Next/Oceanic-Next.md
@@ -9,7 +9,7 @@ permalink: /Oceanic-Next/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/OceanicMaterial/OceanicMaterial.md
+++ b/docs/OceanicMaterial/OceanicMaterial.md
@@ -9,7 +9,7 @@ permalink: /OceanicMaterial/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Ollie/Ollie.md
+++ b/docs/Ollie/Ollie.md
@@ -9,7 +9,7 @@ permalink: /Ollie/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/OneHalfDark/OneHalfDark.md
+++ b/docs/OneHalfDark/OneHalfDark.md
@@ -9,7 +9,7 @@ permalink: /OneHalfDark/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/OneHalfLight/OneHalfLight.md
+++ b/docs/OneHalfLight/OneHalfLight.md
@@ -9,7 +9,7 @@ permalink: /OneHalfLight/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Operator-Mono-Dark/Operator-Mono-Dark.md
+++ b/docs/Operator-Mono-Dark/Operator-Mono-Dark.md
@@ -9,7 +9,7 @@ permalink: /Operator-Mono-Dark/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Overnight-Slumber/Overnight-Slumber.md
+++ b/docs/Overnight-Slumber/Overnight-Slumber.md
@@ -9,7 +9,7 @@ permalink: /Overnight-Slumber/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/PaleNightHC/PaleNightHC.md
+++ b/docs/PaleNightHC/PaleNightHC.md
@@ -9,7 +9,7 @@ permalink: /PaleNightHC/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Pandora/Pandora.md
+++ b/docs/Pandora/Pandora.md
@@ -9,7 +9,7 @@ permalink: /Pandora/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Paraiso-Dark/Paraiso-Dark.md
+++ b/docs/Paraiso-Dark/Paraiso-Dark.md
@@ -9,7 +9,7 @@ permalink: /Paraiso-Dark/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/PaulMillr/PaulMillr.md
+++ b/docs/PaulMillr/PaulMillr.md
@@ -9,7 +9,7 @@ permalink: /PaulMillr/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/PencilDark/PencilDark.md
+++ b/docs/PencilDark/PencilDark.md
@@ -9,7 +9,7 @@ permalink: /PencilDark/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/PencilLight/PencilLight.md
+++ b/docs/PencilLight/PencilLight.md
@@ -9,7 +9,7 @@ permalink: /PencilLight/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Peppermint/Peppermint.md
+++ b/docs/Peppermint/Peppermint.md
@@ -9,7 +9,7 @@ permalink: /Peppermint/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Piatto-Light/Piatto-Light.md
+++ b/docs/Piatto-Light/Piatto-Light.md
@@ -9,7 +9,7 @@ permalink: /Piatto-Light/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Pnevma/Pnevma.md
+++ b/docs/Pnevma/Pnevma.md
@@ -9,7 +9,7 @@ permalink: /Pnevma/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Popping-and-Locking/Popping-and-Locking.md
+++ b/docs/Popping-and-Locking/Popping-and-Locking.md
@@ -9,7 +9,7 @@ permalink: /Popping-and-Locking/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Pro-Light/Pro-Light.md
+++ b/docs/Pro-Light/Pro-Light.md
@@ -9,7 +9,7 @@ permalink: /Pro-Light/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Pro/Pro.md
+++ b/docs/Pro/Pro.md
@@ -9,7 +9,7 @@ permalink: /Pro/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Purple-Rain/Purple-Rain.md
+++ b/docs/Purple-Rain/Purple-Rain.md
@@ -9,7 +9,7 @@ permalink: /Purple-Rain/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Rapture/Rapture.md
+++ b/docs/Rapture/Rapture.md
@@ -9,7 +9,7 @@ permalink: /Rapture/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Raycast-Dark/Raycast-Dark.md
+++ b/docs/Raycast-Dark/Raycast-Dark.md
@@ -9,7 +9,7 @@ permalink: /Raycast-Dark/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Raycast-Light/Raycast-Light.md
+++ b/docs/Raycast-Light/Raycast-Light.md
@@ -9,7 +9,7 @@ permalink: /Raycast-Light/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Red-Alert/Red-Alert.md
+++ b/docs/Red-Alert/Red-Alert.md
@@ -9,7 +9,7 @@ permalink: /Red-Alert/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Red-Planet/Red-Planet.md
+++ b/docs/Red-Planet/Red-Planet.md
@@ -9,7 +9,7 @@ permalink: /Red-Planet/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Red-Sands/Red-Sands.md
+++ b/docs/Red-Sands/Red-Sands.md
@@ -9,7 +9,7 @@ permalink: /Red-Sands/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Relaxed/Relaxed.md
+++ b/docs/Relaxed/Relaxed.md
@@ -9,7 +9,7 @@ permalink: /Relaxed/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Retro/Retro.md
+++ b/docs/Retro/Retro.md
@@ -9,7 +9,7 @@ permalink: /Retro/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Rippedcasts/Rippedcasts.md
+++ b/docs/Rippedcasts/Rippedcasts.md
@@ -9,7 +9,7 @@ permalink: /Rippedcasts/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Rouge-2/Rouge-2.md
+++ b/docs/Rouge-2/Rouge-2.md
@@ -9,7 +9,7 @@ permalink: /Rouge-2/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Royal/Royal.md
+++ b/docs/Royal/Royal.md
@@ -9,7 +9,7 @@ permalink: /Royal/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Ryuuko/Ryuuko.md
+++ b/docs/Ryuuko/Ryuuko.md
@@ -9,7 +9,7 @@ permalink: /Ryuuko/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Sakura/Sakura.md
+++ b/docs/Sakura/Sakura.md
@@ -9,7 +9,7 @@ permalink: /Sakura/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Scarlet-Protocol/Scarlet-Protocol.md
+++ b/docs/Scarlet-Protocol/Scarlet-Protocol.md
@@ -9,7 +9,7 @@ permalink: /Scarlet-Protocol/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/SeaShells/SeaShells.md
+++ b/docs/SeaShells/SeaShells.md
@@ -9,7 +9,7 @@ permalink: /SeaShells/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Seafoam-Pastel/Seafoam-Pastel.md
+++ b/docs/Seafoam-Pastel/Seafoam-Pastel.md
@@ -9,7 +9,7 @@ permalink: /Seafoam-Pastel/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Seti/Seti.md
+++ b/docs/Seti/Seti.md
@@ -9,7 +9,7 @@ permalink: /Seti/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Shaman/Shaman.md
+++ b/docs/Shaman/Shaman.md
@@ -9,7 +9,7 @@ permalink: /Shaman/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Slate/Slate.md
+++ b/docs/Slate/Slate.md
@@ -9,7 +9,7 @@ permalink: /Slate/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/SleepyHollow/SleepyHollow.md
+++ b/docs/SleepyHollow/SleepyHollow.md
@@ -9,7 +9,7 @@ permalink: /SleepyHollow/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Smyck/Smyck.md
+++ b/docs/Smyck/Smyck.md
@@ -9,7 +9,7 @@ permalink: /Smyck/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Snazzy/Snazzy.md
+++ b/docs/Snazzy/Snazzy.md
@@ -9,7 +9,7 @@ permalink: /Snazzy/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/SoftServer/SoftServer.md
+++ b/docs/SoftServer/SoftServer.md
@@ -9,7 +9,7 @@ permalink: /SoftServer/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Solarized-Darcula/Solarized-Darcula.md
+++ b/docs/Solarized-Darcula/Solarized-Darcula.md
@@ -9,7 +9,7 @@ permalink: /Solarized-Darcula/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Solarized-Dark-Higher-Contrast/Solarized-Dark-Higher-Contrast.md
+++ b/docs/Solarized-Dark-Higher-Contrast/Solarized-Dark-Higher-Contrast.md
@@ -9,7 +9,7 @@ permalink: /Solarized-Dark-Higher-Contrast/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Solarized-Dark-Patched/Solarized-Dark-Patched.md
+++ b/docs/Solarized-Dark-Patched/Solarized-Dark-Patched.md
@@ -9,7 +9,7 @@ permalink: /Solarized-Dark-Patched/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/SpaceGray-Eighties-Dull/SpaceGray-Eighties-Dull.md
+++ b/docs/SpaceGray-Eighties-Dull/SpaceGray-Eighties-Dull.md
@@ -9,7 +9,7 @@ permalink: /SpaceGray-Eighties-Dull/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/SpaceGray-Eighties/SpaceGray-Eighties.md
+++ b/docs/SpaceGray-Eighties/SpaceGray-Eighties.md
@@ -9,7 +9,7 @@ permalink: /SpaceGray-Eighties/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/SpaceGray/SpaceGray.md
+++ b/docs/SpaceGray/SpaceGray.md
@@ -9,7 +9,7 @@ permalink: /SpaceGray/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Spacedust/Spacedust.md
+++ b/docs/Spacedust/Spacedust.md
@@ -9,7 +9,7 @@ permalink: /Spacedust/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Spiderman/Spiderman.md
+++ b/docs/Spiderman/Spiderman.md
@@ -9,7 +9,7 @@ permalink: /Spiderman/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Spring/Spring.md
+++ b/docs/Spring/Spring.md
@@ -9,7 +9,7 @@ permalink: /Spring/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Square/Square.md
+++ b/docs/Square/Square.md
@@ -9,7 +9,7 @@ permalink: /Square/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Sublette/Sublette.md
+++ b/docs/Sublette/Sublette.md
@@ -9,7 +9,7 @@ permalink: /Sublette/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Subliminal/Subliminal.md
+++ b/docs/Subliminal/Subliminal.md
@@ -9,7 +9,7 @@ permalink: /Subliminal/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Sundried/Sundried.md
+++ b/docs/Sundried/Sundried.md
@@ -9,7 +9,7 @@ permalink: /Sundried/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Symfonic/Symfonic.md
+++ b/docs/Symfonic/Symfonic.md
@@ -9,7 +9,7 @@ permalink: /Symfonic/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/SynthwaveAlpha/SynthwaveAlpha.md
+++ b/docs/SynthwaveAlpha/SynthwaveAlpha.md
@@ -9,7 +9,7 @@ permalink: /SynthwaveAlpha/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Tango-Adapted/Tango-Adapted.md
+++ b/docs/Tango-Adapted/Tango-Adapted.md
@@ -9,7 +9,7 @@ permalink: /Tango-Adapted/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Tango-Half-Adapted/Tango-Half-Adapted.md
+++ b/docs/Tango-Half-Adapted/Tango-Half-Adapted.md
@@ -9,7 +9,7 @@ permalink: /Tango-Half-Adapted/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Teerb/Teerb.md
+++ b/docs/Teerb/Teerb.md
@@ -9,7 +9,7 @@ permalink: /Teerb/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Terminal-Basic/Terminal-Basic.md
+++ b/docs/Terminal-Basic/Terminal-Basic.md
@@ -9,7 +9,7 @@ permalink: /Terminal-Basic/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Thayer-Bright/Thayer-Bright.md
+++ b/docs/Thayer-Bright/Thayer-Bright.md
@@ -9,7 +9,7 @@ permalink: /Thayer-Bright/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/The-Hulk/The-Hulk.md
+++ b/docs/The-Hulk/The-Hulk.md
@@ -9,7 +9,7 @@ permalink: /The-Hulk/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Tinacious-Design-Dark/Tinacious-Design-Dark.md
+++ b/docs/Tinacious-Design-Dark/Tinacious-Design-Dark.md
@@ -9,7 +9,7 @@ permalink: /Tinacious-Design-Dark/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Tinacious-Design-Light/Tinacious-Design-Light.md
+++ b/docs/Tinacious-Design-Light/Tinacious-Design-Light.md
@@ -9,7 +9,7 @@ permalink: /Tinacious-Design-Light/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Tomorrow-Night-Blue/Tomorrow-Night-Blue.md
+++ b/docs/Tomorrow-Night-Blue/Tomorrow-Night-Blue.md
@@ -9,7 +9,7 @@ permalink: /Tomorrow-Night-Blue/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Tomorrow-Night-Bright/Tomorrow-Night-Bright.md
+++ b/docs/Tomorrow-Night-Bright/Tomorrow-Night-Bright.md
@@ -9,7 +9,7 @@ permalink: /Tomorrow-Night-Bright/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Tomorrow-Night-Burns/Tomorrow-Night-Burns.md
+++ b/docs/Tomorrow-Night-Burns/Tomorrow-Night-Burns.md
@@ -9,7 +9,7 @@ permalink: /Tomorrow-Night-Burns/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Tomorrow-Night-Eighties/Tomorrow-Night-Eighties.md
+++ b/docs/Tomorrow-Night-Eighties/Tomorrow-Night-Eighties.md
@@ -9,7 +9,7 @@ permalink: /Tomorrow-Night-Eighties/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Tomorrow-Night/Tomorrow-Night.md
+++ b/docs/Tomorrow-Night/Tomorrow-Night.md
@@ -9,7 +9,7 @@ permalink: /Tomorrow-Night/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Tomorrow/Tomorrow.md
+++ b/docs/Tomorrow/Tomorrow.md
@@ -9,7 +9,7 @@ permalink: /Tomorrow/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/ToyChest/ToyChest.md
+++ b/docs/ToyChest/ToyChest.md
@@ -9,7 +9,7 @@ permalink: /ToyChest/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Treehouse/Treehouse.md
+++ b/docs/Treehouse/Treehouse.md
@@ -9,7 +9,7 @@ permalink: /Treehouse/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Twilight/Twilight.md
+++ b/docs/Twilight/Twilight.md
@@ -9,7 +9,7 @@ permalink: /Twilight/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Ubuntu/Ubuntu.md
+++ b/docs/Ubuntu/Ubuntu.md
@@ -9,7 +9,7 @@ permalink: /Ubuntu/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/UltraDark/UltraDark.md
+++ b/docs/UltraDark/UltraDark.md
@@ -9,7 +9,7 @@ permalink: /UltraDark/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/UltraViolent/UltraViolent.md
+++ b/docs/UltraViolent/UltraViolent.md
@@ -9,7 +9,7 @@ permalink: /UltraViolent/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/UnderTheSea/UnderTheSea.md
+++ b/docs/UnderTheSea/UnderTheSea.md
@@ -9,7 +9,7 @@ permalink: /UnderTheSea/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Unikitty/Unikitty.md
+++ b/docs/Unikitty/Unikitty.md
@@ -9,7 +9,7 @@ permalink: /Unikitty/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Urple/Urple.md
+++ b/docs/Urple/Urple.md
@@ -9,7 +9,7 @@ permalink: /Urple/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Vaughn/Vaughn.md
+++ b/docs/Vaughn/Vaughn.md
@@ -9,7 +9,7 @@ permalink: /Vaughn/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Vesper/Vesper.md
+++ b/docs/Vesper/Vesper.md
@@ -9,7 +9,7 @@ permalink: /Vesper/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/VibrantInk/VibrantInk.md
+++ b/docs/VibrantInk/VibrantInk.md
@@ -9,7 +9,7 @@ permalink: /VibrantInk/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Violet-Dark/Violet-Dark.md
+++ b/docs/Violet-Dark/Violet-Dark.md
@@ -9,7 +9,7 @@ permalink: /Violet-Dark/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Violet-Light/Violet-Light.md
+++ b/docs/Violet-Light/Violet-Light.md
@@ -9,7 +9,7 @@ permalink: /Violet-Light/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/WarmNeon/WarmNeon.md
+++ b/docs/WarmNeon/WarmNeon.md
@@ -9,7 +9,7 @@ permalink: /WarmNeon/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Wez/Wez.md
+++ b/docs/Wez/Wez.md
@@ -9,7 +9,7 @@ permalink: /Wez/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Whimsy/Whimsy.md
+++ b/docs/Whimsy/Whimsy.md
@@ -9,7 +9,7 @@ permalink: /Whimsy/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/WildCherry/WildCherry.md
+++ b/docs/WildCherry/WildCherry.md
@@ -9,7 +9,7 @@ permalink: /WildCherry/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Wombat/Wombat.md
+++ b/docs/Wombat/Wombat.md
@@ -9,7 +9,7 @@ permalink: /Wombat/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Wryan/Wryan.md
+++ b/docs/Wryan/Wryan.md
@@ -9,7 +9,7 @@ permalink: /Wryan/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/Zenburn/Zenburn.md
+++ b/docs/Zenburn/Zenburn.md
@@ -9,7 +9,7 @@ permalink: /Zenburn/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/arcoiris/arcoiris.md
+++ b/docs/arcoiris/arcoiris.md
@@ -9,7 +9,7 @@ permalink: /arcoiris/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/ayu-light/ayu-light.md
+++ b/docs/ayu-light/ayu-light.md
@@ -9,7 +9,7 @@ permalink: /ayu-light/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/ayu/ayu.md
+++ b/docs/ayu/ayu.md
@@ -9,7 +9,7 @@ permalink: /ayu/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/catppuccin-frappe/catppuccin-frappe.md
+++ b/docs/catppuccin-frappe/catppuccin-frappe.md
@@ -9,7 +9,7 @@ permalink: /catppuccin-frappe/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/catppuccin-latte/catppuccin-latte.md
+++ b/docs/catppuccin-latte/catppuccin-latte.md
@@ -9,7 +9,7 @@ permalink: /catppuccin-latte/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/catppuccin-macchiato/catppuccin-macchiato.md
+++ b/docs/catppuccin-macchiato/catppuccin-macchiato.md
@@ -9,7 +9,7 @@ permalink: /catppuccin-macchiato/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/catppuccin-mocha/catppuccin-mocha.md
+++ b/docs/catppuccin-mocha/catppuccin-mocha.md
@@ -9,7 +9,7 @@ permalink: /catppuccin-mocha/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/coffee-theme/coffee-theme.md
+++ b/docs/coffee-theme/coffee-theme.md
@@ -9,7 +9,7 @@ permalink: /coffee-theme/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/cyberpunk/cyberpunk.md
+++ b/docs/cyberpunk/cyberpunk.md
@@ -9,7 +9,7 @@ permalink: /cyberpunk/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/darkermatrix/darkermatrix.md
+++ b/docs/darkermatrix/darkermatrix.md
@@ -9,7 +9,7 @@ permalink: /darkermatrix/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/darkmatrix/darkmatrix.md
+++ b/docs/darkmatrix/darkmatrix.md
@@ -9,7 +9,7 @@ permalink: /darkmatrix/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/dayfox/dayfox.md
+++ b/docs/dayfox/dayfox.md
@@ -9,7 +9,7 @@ permalink: /dayfox/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/deep/deep.md
+++ b/docs/deep/deep.md
@@ -9,7 +9,7 @@ permalink: /deep/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/duckbones/duckbones.md
+++ b/docs/duckbones/duckbones.md
@@ -9,7 +9,7 @@ permalink: /duckbones/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/farmhouse-dark/farmhouse-dark.md
+++ b/docs/farmhouse-dark/farmhouse-dark.md
@@ -9,7 +9,7 @@ permalink: /farmhouse-dark/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/farmhouse-light/farmhouse-light.md
+++ b/docs/farmhouse-light/farmhouse-light.md
@@ -9,7 +9,7 @@ permalink: /farmhouse-light/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/flexoki-dark/flexoki-dark.md
+++ b/docs/flexoki-dark/flexoki-dark.md
@@ -9,7 +9,7 @@ permalink: /flexoki-dark/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/flexoki-light/flexoki-light.md
+++ b/docs/flexoki-light/flexoki-light.md
@@ -9,7 +9,7 @@ permalink: /flexoki-light/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/iTerm2-Dark-Background/iTerm2-Dark-Background.md
+++ b/docs/iTerm2-Dark-Background/iTerm2-Dark-Background.md
@@ -9,7 +9,7 @@ permalink: /iTerm2-Dark-Background/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/iTerm2-Default/iTerm2-Default.md
+++ b/docs/iTerm2-Default/iTerm2-Default.md
@@ -9,7 +9,7 @@ permalink: /iTerm2-Default/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/iTerm2-Light-Background/iTerm2-Light-Background.md
+++ b/docs/iTerm2-Light-Background/iTerm2-Light-Background.md
@@ -9,7 +9,7 @@ permalink: /iTerm2-Light-Background/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/iTerm2-Pastel-Dark-Background/iTerm2-Pastel-Dark-Background.md
+++ b/docs/iTerm2-Pastel-Dark-Background/iTerm2-Pastel-Dark-Background.md
@@ -9,7 +9,7 @@ permalink: /iTerm2-Pastel-Dark-Background/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/iTerm2-Smoooooth/iTerm2-Smoooooth.md
+++ b/docs/iTerm2-Smoooooth/iTerm2-Smoooooth.md
@@ -9,7 +9,7 @@ permalink: /iTerm2-Smoooooth/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/iTerm2-Solarized-Dark/iTerm2-Solarized-Dark.md
+++ b/docs/iTerm2-Solarized-Dark/iTerm2-Solarized-Dark.md
@@ -9,7 +9,7 @@ permalink: /iTerm2-Solarized-Dark/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/iTerm2-Solarized-Light/iTerm2-Solarized-Light.md
+++ b/docs/iTerm2-Solarized-Light/iTerm2-Solarized-Light.md
@@ -9,7 +9,7 @@ permalink: /iTerm2-Solarized-Light/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/iTerm2-Tango-Dark/iTerm2-Tango-Dark.md
+++ b/docs/iTerm2-Tango-Dark/iTerm2-Tango-Dark.md
@@ -9,7 +9,7 @@ permalink: /iTerm2-Tango-Dark/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/iTerm2-Tango-Light/iTerm2-Tango-Light.md
+++ b/docs/iTerm2-Tango-Light/iTerm2-Tango-Light.md
@@ -9,7 +9,7 @@ permalink: /iTerm2-Tango-Light/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/iceberg-dark/iceberg-dark.md
+++ b/docs/iceberg-dark/iceberg-dark.md
@@ -9,7 +9,7 @@ permalink: /iceberg-dark/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/iceberg-light/iceberg-light.md
+++ b/docs/iceberg-light/iceberg-light.md
@@ -9,7 +9,7 @@ permalink: /iceberg-light/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/idea/idea.md
+++ b/docs/idea/idea.md
@@ -9,7 +9,7 @@ permalink: /idea/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/idleToes/idleToes.md
+++ b/docs/idleToes/idleToes.md
@@ -9,7 +9,7 @@ permalink: /idleToes/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/index.markdown
+++ b/docs/index.markdown
@@ -7,7 +7,7 @@ description: 4bit css
 ---
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ permalink: /
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/index.ps.markdown
+++ b/docs/index.ps.markdown
@@ -7,7 +7,7 @@ description: 4bit css
 ---
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/jubi/jubi.md
+++ b/docs/jubi/jubi.md
@@ -9,7 +9,7 @@ permalink: /jubi/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/kanagawabones/kanagawabones.md
+++ b/docs/kanagawabones/kanagawabones.md
@@ -9,7 +9,7 @@ permalink: /kanagawabones/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/lovelace/lovelace.md
+++ b/docs/lovelace/lovelace.md
@@ -9,7 +9,7 @@ permalink: /lovelace/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/matrix/matrix.md
+++ b/docs/matrix/matrix.md
@@ -9,7 +9,7 @@ permalink: /matrix/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/midnight-in-mojave/midnight-in-mojave.md
+++ b/docs/midnight-in-mojave/midnight-in-mojave.md
@@ -9,7 +9,7 @@ permalink: /midnight-in-mojave/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/neobones-dark/neobones-dark.md
+++ b/docs/neobones-dark/neobones-dark.md
@@ -9,7 +9,7 @@ permalink: /neobones-dark/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/neobones-light/neobones-light.md
+++ b/docs/neobones-light/neobones-light.md
@@ -9,7 +9,7 @@ permalink: /neobones-light/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/nightfox/nightfox.md
+++ b/docs/nightfox/nightfox.md
@@ -9,7 +9,7 @@ permalink: /nightfox/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/niji/niji.md
+++ b/docs/niji/niji.md
@@ -9,7 +9,7 @@ permalink: /niji/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/nord-light/nord-light.md
+++ b/docs/nord-light/nord-light.md
@@ -9,7 +9,7 @@ permalink: /nord-light/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/nord/nord.md
+++ b/docs/nord/nord.md
@@ -9,7 +9,7 @@ permalink: /nord/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/primary/primary.md
+++ b/docs/primary/primary.md
@@ -9,7 +9,7 @@ permalink: /primary/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/purplepeter/purplepeter.md
+++ b/docs/purplepeter/purplepeter.md
@@ -9,7 +9,7 @@ permalink: /purplepeter/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/rebecca/rebecca.md
+++ b/docs/rebecca/rebecca.md
@@ -9,7 +9,7 @@ permalink: /rebecca/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/rose-pine-dawn/rose-pine-dawn.md
+++ b/docs/rose-pine-dawn/rose-pine-dawn.md
@@ -9,7 +9,7 @@ permalink: /rose-pine-dawn/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/rose-pine-moon/rose-pine-moon.md
+++ b/docs/rose-pine-moon/rose-pine-moon.md
@@ -9,7 +9,7 @@ permalink: /rose-pine-moon/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/rose-pine/rose-pine.md
+++ b/docs/rose-pine/rose-pine.md
@@ -9,7 +9,7 @@ permalink: /rose-pine/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/seoulbones-dark/seoulbones-dark.md
+++ b/docs/seoulbones-dark/seoulbones-dark.md
@@ -9,7 +9,7 @@ permalink: /seoulbones-dark/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/seoulbones-light/seoulbones-light.md
+++ b/docs/seoulbones-light/seoulbones-light.md
@@ -9,7 +9,7 @@ permalink: /seoulbones-light/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/shades-of-purple/shades-of-purple.md
+++ b/docs/shades-of-purple/shades-of-purple.md
@@ -9,7 +9,7 @@ permalink: /shades-of-purple/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/synthwave-everything/synthwave-everything.md
+++ b/docs/synthwave-everything/synthwave-everything.md
@@ -9,7 +9,7 @@ permalink: /synthwave-everything/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/synthwave/synthwave.md
+++ b/docs/synthwave/synthwave.md
@@ -9,7 +9,7 @@ permalink: /synthwave/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/terafox/terafox.md
+++ b/docs/terafox/terafox.md
@@ -9,7 +9,7 @@ permalink: /terafox/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/tokyonight-day/tokyonight-day.md
+++ b/docs/tokyonight-day/tokyonight-day.md
@@ -9,7 +9,7 @@ permalink: /tokyonight-day/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/tokyonight-storm/tokyonight-storm.md
+++ b/docs/tokyonight-storm/tokyonight-storm.md
@@ -9,7 +9,7 @@ permalink: /tokyonight-storm/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/tokyonight/tokyonight.md
+++ b/docs/tokyonight/tokyonight.md
@@ -9,7 +9,7 @@ permalink: /tokyonight/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/vimbones/vimbones.md
+++ b/docs/vimbones/vimbones.md
@@ -9,7 +9,7 @@ permalink: /vimbones/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/wilmersdorf/wilmersdorf.md
+++ b/docs/wilmersdorf/wilmersdorf.md
@@ -9,7 +9,7 @@ permalink: /wilmersdorf/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/zenbones-dark/zenbones-dark.md
+++ b/docs/zenbones-dark/zenbones-dark.md
@@ -9,7 +9,7 @@ permalink: /zenbones-dark/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/zenbones-light/zenbones-light.md
+++ b/docs/zenbones-light/zenbones-light.md
@@ -9,7 +9,7 @@ permalink: /zenbones-light/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/zenbones/zenbones.md
+++ b/docs/zenbones/zenbones.md
@@ -9,7 +9,7 @@ permalink: /zenbones/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/zenburned/zenburned.md
+++ b/docs/zenburned/zenburned.md
@@ -9,7 +9,7 @@ permalink: /zenburned/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/zenwritten-dark/zenwritten-dark.md
+++ b/docs/zenwritten-dark/zenwritten-dark.md
@@ -9,7 +9,7 @@ permalink: /zenwritten-dark/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 

--- a/docs/zenwritten-light/zenwritten-light.md
+++ b/docs/zenwritten-light/zenwritten-light.md
@@ -9,7 +9,7 @@ permalink: /zenwritten-light/
 
 <h2 style='text-align:center'>
     <a id='colorSchemeNameLink' href='#'>
-        <span class='ColorSchemeFileName' />
+        <span class='ColorSchemeFileName'></span>
     </a>
 </h2>
 


### PR DESCRIPTION
Templates used self closing tags on tags that are not, this breaks the hierarchy. 
Fixes #67 

### Changes are tiny

Despite the file count. 99% of them are a single replacement, without regex.

```yml
nonRegexMatch: "<span class='ColorSchemeFileName' />"
replacement: "<span class='ColorSchemeFileName'></span>"
```
### The remaining files changed were:

- docs\index.markdown
- docs\index.md
- docs\index.ps.markdown

see: https://developer.mozilla.org/en-US/docs/Glossary/Void_element#self-closing_tags